### PR TITLE
Changes to support proper work of Multiple Captures features

### DIFF
--- a/Annotations/Classes/Views/Canvas/CanvasView.swift
+++ b/Annotations/Classes/Views/Canvas/CanvasView.swift
@@ -15,6 +15,7 @@ public protocol CanvasViewDelegate {
   func canvasView(_ canvasView: CanvasView, didCreateAnnotation annotation: CanvasDrawable)
   func canvasView(_ canvasView: CanvasView, didStartEditing annotation: TextAnnotation)
   func canvasView(_ canvasView: CanvasView, didEndEditing annotation: TextAnnotation)
+  func canvasView(_ canvasView: CanvasView, didDeselect annotation: TextAnnotation)
 }
 
 public protocol CanvasView: class {

--- a/Annotations/Classes/Views/Canvas/CanvasViewClass.swift
+++ b/Annotations/Classes/Views/Canvas/CanvasViewClass.swift
@@ -194,8 +194,11 @@ extension CanvasViewClass {
   }
   
   public func deselectTextAnnotation() {
-    selectedTextAnnotation?.deselect()
-    selectedTextAnnotation = nil
+    guard let selectedTextAnnotation = self.selectedTextAnnotation else { return }
+    selectedTextAnnotation.deselect()
+    self.selectedTextAnnotation = nil
+    
+    delegate?.canvasView(self, didDeselect: selectedTextAnnotation)
   }
   
   // MARK: - Update items color


### PR DESCRIPTION
1. Add delegate callback `func canvasView(_ canvasView: CanvasView, didDeselect annotation: TextAnnotation)`. The reason to add it is to add a possibility to update the first responder in the delegate that can be needed to ensure that textAnnotation and all its parts are resigned from the first responder state.