### PR TITLE
Improve logic to fix legibility left clipping for larger fonts

### DIFF
--- a/Annotations/Classes/TextAnnotation/MouseEventsHandler.swift
+++ b/Annotations/Classes/TextAnnotation/MouseEventsHandler.swift
@@ -145,14 +145,14 @@ class MouseEventsHandler {
     guard let textContainerView = self.textContainerView,
           let textView = self.textView else { return nil }
 
-    if textView.frame.contains(location) {
-      return .move
-    } else if textContainerView.leftKnobView.frame.contains(location) {
+    if textContainerView.leftKnobView.frame.contains(location) {
       return .resize(type: .leftToRight)
     } else if textContainerView.rightKnobView.frame.contains(location) {
       return .resize(type: .rightToLeft)
     } else if textContainerView.scaleKnobView.frame.contains(location) {
       return .scale
+    } else if textView.frame.contains(location) {
+      return .move
     }
     
     return nil

--- a/Annotations/Classes/TextAnnotation/TextContainerView.swift
+++ b/Annotations/Classes/TextAnnotation/TextContainerView.swift
@@ -51,7 +51,7 @@ public class TextContainerView: NSView, TextAnnotation {
   let inset = CGVector(dx: 15.0, dy: 50.0)
   
   // selection view inset to textView
-  let selectionViewInset = CGVector(dx: -10.0, dy: -10.0)
+  let selectionViewInset = CGVector(dx: -5.0, dy: -10.0)
   
   // Decorating params (for the active state when SelectionView and knobs are visible)
   let decParams = DecoratorStyleParams.defaultParams
@@ -88,7 +88,7 @@ public class TextContainerView: NSView, TextAnnotation {
       rightKnobView.frame = CGRect(x: x1, y: y1, width: knobSide, height: knobSide)
       
       // layout scale knob view
-      let x2 = selectionView.frame.size.width / 2.0
+      let x2 = selectionView.frame.origin.x + selectionView.frame.size.width / 2.0 - scaleKnobSide / 2.0
       let y2 = frame.height - selectionView.frame.origin.y - scaleKnobSide / 2.0  - lineWidth / 4.0
       scaleKnobView.frame = CGRect(x: x2, y: y2, width: scaleKnobSide, height: scaleKnobSide)
       
@@ -145,6 +145,7 @@ public class TextContainerView: NSView, TextAnnotation {
     }
   }
   
+  
   // MARK: - Views
   
   lazy var textView: TextView = {
@@ -200,6 +201,8 @@ public class TextContainerView: NSView, TextAnnotation {
       self.updateLegibilityButton(with: self.legibilityEffectEnabled)
     }
   }
+  
+  static let textViewsLineFragmentPadding: CGFloat = 10.0
   
   // MARK: - Properties
   var debugMode: Bool = false
@@ -301,6 +304,11 @@ public class TextContainerView: NSView, TextAnnotation {
     updateParts(with: .inactive, oldValue: nil)
     
     textView.delegate = self
+    
+   
+    textView.textContainer?.lineFragmentPadding = Self.textViewsLineFragmentPadding
+    legibilityTextView.textContainer?.lineFragmentPadding = Self.textViewsLineFragmentPadding
+  
   }
   
   func setupTextView(_ textView: NSTextView) {

--- a/Annotations/Classes/TextAnnotation/TextFrameTransformer.swift
+++ b/Annotations/Classes/TextAnnotation/TextFrameTransformer.swift
@@ -16,8 +16,12 @@ class TextFrameTransformer {
   
   // must use this in width calculation otherwise the width will be incorrect
   var containerLinePadding: CGFloat {
+    singleContainerLinePadding * 2.0
+  }
+  
+  var singleContainerLinePadding: CGFloat {
     guard let textContainer = textView?.textContainer else { return 0 }
-    return textContainer.lineFragmentPadding * 2.0
+    return textContainer.lineFragmentPadding
   }
   
   // MARK: - Transform
@@ -80,8 +84,10 @@ class TextFrameTransformer {
   
   func updateSize(for text: String) {
     guard let textView = textView else { return }
-    let size = stringSizeHelper.bestSizeWithAttributes(for: text,
+    var size = stringSizeHelper.bestSizeWithAttributes(for: text,
                                                        attributes: textView.typingAttributes)
+    
+    size.width += containerLinePadding
     updateTextViewSize(size: size)
   }
   
@@ -92,7 +98,7 @@ class TextFrameTransformer {
     var newWidth = stringSizeHelper.getWidthAttr(for: textView.attributedString(),
                                                  height: textView.frame.size.height)
     
-    newWidth += containerLinePadding
+    newWidth += singleContainerLinePadding // need padding from the left side only here
     
     // text view width need to be reduced only if a new width is less than the current one
     if newWidth < textView.frame.size.width {


### PR DESCRIPTION
@memstel this PR adds changes to improve logic to fix legibility left clipping for larger fonts.

It is not the perfect solution and very large font size (if a user scales it) still can be clipped but it is the best one I was able to implement by this time.

![Screen Cast 2020-10-02 at 8 49 33 PM](https://user-images.githubusercontent.com/15073398/94953841-e2e12480-04f0-11eb-8551-7a3e0c817841.gif)
