### PR TITLE
Add support of zPosition for Pens, Rects, Arrows, Numbers and Texts

### DIFF
--- a/Annotations/Classes/Model/ArrowModel.swift
+++ b/Annotations/Classes/Model/ArrowModel.swift
@@ -14,6 +14,7 @@ public enum ArrowPoint: CaseIterable {
 }
 
 public struct ArrowModel: Model {
+  public var zPosition: CGFloat = 0
   public var index: Int
   public let origin: PointModel
   public let to: PointModel

--- a/Annotations/Classes/Model/NumberModel.swift
+++ b/Annotations/Classes/Model/NumberModel.swift
@@ -4,6 +4,7 @@ public struct NumberModel: Model {
   
   static let defaultRadius: CGFloat = 15.0
   
+  public var zPosition: CGFloat = 0
   public var index: Int
     
   static func modelWithRadius(index: Int, centerPoint: PointModel, radius: CGFloat, number: UInt, color: ModelColor) -> NumberModel {

--- a/Annotations/Classes/Model/PenModel.swift
+++ b/Annotations/Classes/Model/PenModel.swift
@@ -9,6 +9,7 @@
 import Foundation
 
 public struct PenModel: Model {
+  public var zPosition: CGFloat = 0
   public var index: Int
   public var points: [PointModel]
   public let color: ModelColor

--- a/Annotations/Classes/Model/RectModel.swift
+++ b/Annotations/Classes/Model/RectModel.swift
@@ -17,6 +17,7 @@ public enum RectPoint: CaseIterable {
 let widthDot: Double = 0
 
 public class RectModel: Model {
+  public var zPosition: CGFloat = 0
   public var index: Int
   public let origin: PointModel
   public let to: PointModel

--- a/Annotations/Classes/Model/TextModel.swift
+++ b/Annotations/Classes/Model/TextModel.swift
@@ -8,6 +8,7 @@
 import Foundation
 
 public struct TextModel: Model, TextAnnotationModelable {
+  public var zPosition: CGFloat = 0
   public var index: Int
   public let origin: PointModel
   public let text: String

--- a/Annotations/Classes/TextAnnotation/Dependencies/TextAnnotation.swift
+++ b/Annotations/Classes/TextAnnotation/Dependencies/TextAnnotation.swift
@@ -33,8 +33,11 @@ extension TextAnnotation {
     state = .inactive
   }
   
-  public func addTo(canvas: TextAnnotationCanvas) {
+  public func addTo(canvas: TextAnnotationCanvas, zPosition: CGFloat?) {
     canvas.add(textAnnotation: self)
+    if let zPosition = zPosition {
+      layer?.zPosition = zPosition
+    }
   }
 }
 

--- a/Annotations/Classes/TextAnnotation/TextContainerView.swift
+++ b/Annotations/Classes/TextAnnotation/TextContainerView.swift
@@ -273,9 +273,8 @@ public class TextContainerView: NSView, TextAnnotation {
   
   // MARK: - Initial setup
   func performSubfieldsInit(frameRect: CGRect, textParams: TextParams, enableEmojies: Bool) {
-    
+    wantsLayer = true
     if debugMode {
-      wantsLayer = true
       layer?.borderColor = NSColor.black.cgColor
       layer?.borderWidth = 1.0
     }

--- a/Annotations/Classes/Views/ArrowCanvas.swift
+++ b/Annotations/Classes/Views/ArrowCanvas.swift
@@ -2,7 +2,7 @@ import Foundation
 
 protocol ArrowCanvas: class, ArrowViewDelegate {
   var model: CanvasModel { get set }
-  func add(_ item: CanvasDrawable)
+  func add(_ item: CanvasDrawable, zPosition: CGFloat?)
 }
 
 extension ArrowCanvas {
@@ -14,7 +14,7 @@ extension ArrowCanvas {
                          globalIndex: model.index,
                          color: model.color)
     view.delegate = self
-    add(view)
+    add(view, zPosition: model.zPosition)
   }
   
   func createArrowView(origin: PointModel, to: PointModel, color: ModelColor) -> (CanvasDrawable?, KnobView?) {

--- a/Annotations/Classes/Views/ArrowView.swift
+++ b/Annotations/Classes/Views/ArrowView.swift
@@ -109,6 +109,11 @@ class ArrowView: CanvasDrawable, DrawableView {
     state.model = model.copyMoving(arrowPoint: arrowPoint, delta: delta)
   }
   
+  func bringToTop(canvas: CanvasView) {
+    canvas.setMaximumZPosition(to: layer)
+    state.model.zPosition = layer.zPosition
+  }
+  
   func render(state: ArrowViewState, oldState: ArrowViewState? = nil) {
     if state.model != oldState?.model {
       layer.shapePath = Self.createPath(model: state.model)

--- a/Annotations/Classes/Views/ArrowView.swift
+++ b/Annotations/Classes/Views/ArrowView.swift
@@ -9,7 +9,7 @@ struct ArrowViewState {
   var isSelected: Bool
 }
 
-class ArrowView: CanvasDrawable {
+class ArrowView: CanvasDrawable, DrawableView {
   var state: ArrowViewState {
     didSet {
       render(state: state, oldState: oldValue)
@@ -94,19 +94,6 @@ class ArrowView: CanvasDrawable {
   
   func knobAt(arrowPoint: ArrowPoint) -> KnobView {
     return knobDict[arrowPoint]!
-  }
-  
-  func contains(point: PointModel) -> Bool {
-    return layer.path!.contains(point.cgPoint)
-  }
-  
-  func addTo(canvas: CanvasView) {
-    canvas.canvasLayer.addSublayer(layer)
-  }
-  
-  func removeFrom(canvas: CanvasView) {
-    layer.removeFromSuperlayer()
-    knobs.forEach { $0.removeFrom(canvas: canvas) }
   }
   
   func dragged(from: PointModel, to: PointModel) {

--- a/Annotations/Classes/Views/Canvas/CanvasDrawable.swift
+++ b/Annotations/Classes/Views/Canvas/CanvasDrawable.swift
@@ -9,7 +9,7 @@ public protocol CanvasDrawable: class {
   var color: NSColor? { get }
   
   func updateColor(_ color: NSColor)
-  func addTo(canvas: CanvasView)
+  func addTo(canvas: CanvasView, zPosition: CGFloat?)
   func removeFrom(canvas: CanvasView)
   func bringToTop(canvas: CanvasView)
   func contains(point: PointModel) -> Bool

--- a/Annotations/Classes/Views/Canvas/CanvasDrawable.swift
+++ b/Annotations/Classes/Views/Canvas/CanvasDrawable.swift
@@ -11,6 +11,7 @@ public protocol CanvasDrawable: class {
   func updateColor(_ color: NSColor)
   func addTo(canvas: CanvasView)
   func removeFrom(canvas: CanvasView)
+  func bringToTop(canvas: CanvasView)
   func contains(point: PointModel) -> Bool
   func knobAt(point: PointModel) -> KnobView?
   func draggedKnob(_ knob: KnobView, from: PointModel, to: PointModel)
@@ -26,6 +27,10 @@ extension CanvasDrawable {
   // this method is called to perform some actions after adding to the canvas
   // override if some initial actions are required (like start text editing after adding to the canvas)
   func doInitialSetupOnCanvas() {
+    
+  }
+  
+  func bringToTop(canvas: CanvasView) {
     
   }
 }

--- a/Annotations/Classes/Views/Canvas/CanvasView.swift
+++ b/Annotations/Classes/Views/Canvas/CanvasView.swift
@@ -87,7 +87,7 @@ public class CanvasView: NSView, ArrowCanvas, PenCanvas, RectCanvas, TextCanvas,
   public var solidColorForObsfuscate: Bool = false
   
   // MARK: - ZPosition
-  private var currentZPosition: Int = 0
+  private(set) var currentZPosition: Int = 0
   
   func generateZPosition() -> CGFloat {
     currentZPosition += 1
@@ -183,7 +183,8 @@ public class CanvasView: NSView, ArrowCanvas, PenCanvas, RectCanvas, TextCanvas,
         params.foregroundColor = color
       }
       return createTextView(origin: mouseDown,
-                            params: params)
+                            params: params,
+                            zPosition: 0)
     case .number:
       return createNumberView(origin: mouseDown,
                               color: color).0
@@ -217,7 +218,7 @@ public class CanvasView: NSView, ArrowCanvas, PenCanvas, RectCanvas, TextCanvas,
   }
   
   public func add(_ item: CanvasDrawable, zPosition: CGFloat?) {
-    item.addTo(canvas: self)
+    item.addTo(canvas: self, zPosition: zPosition)
     items.append(item)
     
     delegate?.canvasView(self, didCreateAnnotation: item)

--- a/Annotations/Classes/Views/Canvas/CanvasView.swift
+++ b/Annotations/Classes/Views/Canvas/CanvasView.swift
@@ -85,7 +85,15 @@ public class CanvasView: NSView, ArrowCanvas, PenCanvas, RectCanvas, TextCanvas,
   var obfuscateCanvasLayer: CALayer = CALayer() // palette layer
   var obfuscateMaskLayers: CALayer = CALayer() // obfuscate views are added here to be a mask of canvas layer
   public var solidColorForObsfuscate: Bool = false
-
+  
+  // MARK: - ZPosition
+  private var currentZPosition: Int = 0
+  
+  func generateZPosition() -> CGFloat {
+    currentZPosition += 1
+    return CGFloat(currentZPosition)
+  }
+  
   // MARK: - Initializers
   
   override init(frame frameRect: NSRect) {
@@ -208,11 +216,16 @@ public class CanvasView: NSView, ArrowCanvas, PenCanvas, RectCanvas, TextCanvas,
     }
   }
   
-  public func add(_ item: CanvasDrawable) {
+  public func add(_ item: CanvasDrawable, zPosition: CGFloat?) {
     item.addTo(canvas: self)
     items.append(item)
     
     delegate?.canvasView(self, didCreateAnnotation: item)
+  }
+  
+  func setMaximumZPosition(to layer: CALayer) {
+    currentZPosition += 1
+    layer.zPosition = CGFloat(currentZPosition)
   }
   
   // MARK: - Delete item

--- a/Annotations/Classes/Views/Canvas/CanvasViewEventsHandler.swift
+++ b/Annotations/Classes/Views/Canvas/CanvasViewEventsHandler.swift
@@ -24,7 +24,7 @@ class CanvasViewEventsHandler {
       if !canvasItemSelected {
         if let newItem = canvasView.createItem(mouseDown: point,
                                                color: canvasView.createColor) {
-          canvasView.add(newItem)
+          canvasView.add(newItem, zPosition: canvasView.generateZPosition())
           newItem.doInitialSetupOnCanvas()
           return
         }
@@ -38,6 +38,7 @@ class CanvasViewEventsHandler {
         // select an item if any at the point
       } else if let item = itemAt(point: point) {
         canvasView.selectedItem = item
+        item.bringToTop(canvas: canvasView)
         item.isSelected = true
         return
       }
@@ -48,7 +49,7 @@ class CanvasViewEventsHandler {
       
       guard let newItem = canvasView.createItem(mouseDown: point,
                                                 color: canvasView.createColor) else { return }
-      canvasView.add(newItem)
+      canvasView.add(newItem, zPosition: canvasView.generateZPosition())
       newItem.doInitialSetupOnCanvas()
       newItem.isSelected = true
       canvasView.selectedItem = newItem
@@ -102,7 +103,7 @@ class CanvasViewEventsHandler {
         return
       }
       
-      canvasView.add(item)
+      canvasView.add(item, zPosition: canvasView.generateZPosition())
       canvasView.selectedItem = item
       canvasView.selectedKnob = newKnob
       isChanged = true

--- a/Annotations/Classes/Views/Common/DrawableView.swift
+++ b/Annotations/Classes/Views/Common/DrawableView.swift
@@ -2,18 +2,25 @@ import Cocoa
 
 protocol DrawableView: CanvasDrawable {
   var layer: CAShapeLayer { get }
+  var knobs: [KnobView] { get }
 }
 
 extension DrawableView {
   func addTo(canvas: CanvasView) {
     canvas.canvasLayer.addSublayer(layer)
+    canvas.setMaximumZPosition(to: layer)
   }
   
   func removeFrom(canvas: CanvasView) {
     layer.removeFromSuperlayer()
+    knobs.forEach { $0.removeFrom(canvas: canvas) }
   }
   
   func contains(point: PointModel) -> Bool {
     layer.path!.contains(point.cgPoint)
+  }
+  
+  func bringToTop(canvas: CanvasView) {
+    canvas.setMaximumZPosition(to: layer)
   }
 }

--- a/Annotations/Classes/Views/Common/DrawableView.swift
+++ b/Annotations/Classes/Views/Common/DrawableView.swift
@@ -6,9 +6,13 @@ protocol DrawableView: CanvasDrawable {
 }
 
 extension DrawableView {
-  func addTo(canvas: CanvasView) {
+  func addTo(canvas: CanvasView, zPosition: CGFloat?) {
     canvas.canvasLayer.addSublayer(layer)
-    canvas.setMaximumZPosition(to: layer)
+    if let zPosition = zPosition {
+      layer.zPosition = zPosition
+    } else {
+      canvas.setMaximumZPosition(to: layer)
+    }
   }
   
   func removeFrom(canvas: CanvasView) {

--- a/Annotations/Classes/Views/HighlightCanvas.swift
+++ b/Annotations/Classes/Views/HighlightCanvas.swift
@@ -2,7 +2,7 @@ import Foundation
 
 protocol HighlightCanvas: class, HighlightViewDelegate {
   var model: CanvasModel { get set }
-  func add(_ item: CanvasDrawable)
+  func add(_ item: CanvasDrawable, zPosition: CGFloat?)
 }
 
 extension HighlightCanvas {
@@ -16,7 +16,7 @@ extension HighlightCanvas {
                              maskRects: rects,
                              color: model.color)
     view.delegate = self
-    add(view)
+    add(view, zPosition: nil)
   }
   
   func createHighlightView(origin: PointModel, to: PointModel, color: ModelColor, size: CGSize) -> (CanvasDrawable?, KnobView?) {

--- a/Annotations/Classes/Views/HiglightView.swift
+++ b/Annotations/Classes/Views/HiglightView.swift
@@ -146,7 +146,7 @@ class HighlightView: CanvasDrawable {
     return canvas.canvasLayer.sublayers?.filter { type(of: $0) == HighlightLayer.self } as? [HighlightLayer] ?? []
   }
   
-  func addTo(canvas: CanvasView) {
+  func addTo(canvas: CanvasView, zPosition: CGFloat?) {
     var maskLayer: HighlightLayerMask
     if let parent = parentLayer(from: canvas) {
       parent.addSublayer(layer)

--- a/Annotations/Classes/Views/Number/NumberCanvas.swift
+++ b/Annotations/Classes/Views/Number/NumberCanvas.swift
@@ -2,7 +2,7 @@ import Foundation
 
 protocol NumberCanvas: CanvasDrawableDelegate {
   var model: CanvasModel { get set }
-  func add(_ item: CanvasDrawable)
+  func add(_ item: CanvasDrawable, zPosition: CGFloat?)
 }
 
 extension NumberCanvas {
@@ -15,7 +15,7 @@ extension NumberCanvas {
                           globalIndex: model.index,
                           color: model.color)
     view.delegate = self
-    add(view)
+    add(view, zPosition: model.zPosition)
   }
   
   func createNumberView(origin: PointModel, color: ModelColor) -> (CanvasDrawable?, KnobView?) {

--- a/Annotations/Classes/Views/ObfuscateCanvas.swift
+++ b/Annotations/Classes/Views/ObfuscateCanvas.swift
@@ -2,7 +2,7 @@ import Foundation
 
 protocol ObfuscateCanvas: class, ObfuscateViewDelegate {
   var model: CanvasModel { get set }
-  func add(_ item: CanvasDrawable)
+  func add(_ item: CanvasDrawable, zPosition: CGFloat?)
 }
 
 extension ObfuscateCanvas {
@@ -14,7 +14,7 @@ extension ObfuscateCanvas {
                              globalIndex: model.index,
                              color: model.color)
     view.delegate = self
-    add(view)
+    add(view, zPosition: nil)
   }
   
   func createObfuscateView(origin: PointModel, to: PointModel, color: ModelColor) -> (CanvasDrawable?, KnobView?) {

--- a/Annotations/Classes/Views/ObfuscateView.swift
+++ b/Annotations/Classes/Views/ObfuscateView.swift
@@ -106,7 +106,7 @@ class ObfuscateView: CanvasDrawable {
     return layer.path!.contains(point.cgPoint)
   }
   
-  func addTo(canvas: CanvasView) {
+  func addTo(canvas: CanvasView, zPosition: CGFloat?) {
     self.canvasView = canvas
     canvas.obfuscateMaskLayers.addSublayer(layer)
   }

--- a/Annotations/Classes/Views/PenCanvas.swift
+++ b/Annotations/Classes/Views/PenCanvas.swift
@@ -2,7 +2,7 @@ import Foundation
 
 protocol PenCanvas: class, PenViewDelegate {
   var model: CanvasModel { get set }
-  func add(_ item: CanvasDrawable)
+  func add(_ item: CanvasDrawable, zPosition: CGFloat?)
 }
 
 extension PenCanvas {
@@ -14,7 +14,7 @@ extension PenCanvas {
                        globalIndex: model.index,
                       color: model.color)
     view.delegate = self
-    add(view)
+    add(view, zPosition: model.zPosition)
   }
   
   func createPenView(origin: PointModel, to: PointModel, color: ModelColor) -> (CanvasDrawable?, KnobView?) {

--- a/Annotations/Classes/Views/PenView.swift
+++ b/Annotations/Classes/Views/PenView.swift
@@ -9,7 +9,7 @@ struct PenViewState {
   var isSelected: Bool
 }
 
-class PenView: CanvasDrawable {
+class PenView: CanvasDrawable, DrawableView {
   var delegate: PenViewDelegate?
   var layer: CAShapeLayer
   
@@ -37,6 +37,8 @@ class PenView: CanvasDrawable {
   static var modelType: CanvasItemType { return .pen }
   
   var model: PenModel { return state.model }
+  
+  var knobs: [KnobView] { [] }
 
   var isSelected: Bool {
     get { return state.isSelected }
@@ -58,15 +60,7 @@ class PenView: CanvasDrawable {
     
     return layer
   }
-  
-  func addTo(canvas: CanvasView) {
-    canvas.canvasLayer.addSublayer(layer)
-  }
-  
-  func removeFrom(canvas: CanvasView) {
-    layer.removeFromSuperlayer()
-  }
-  
+
   func contains(point: PointModel) -> Bool {
     let tapTargetPath = layer.path!.copy(strokingWithWidth: 10, lineCap: .butt, lineJoin: .miter, miterLimit: 1)
 

--- a/Annotations/Classes/Views/PenView.swift
+++ b/Annotations/Classes/Views/PenView.swift
@@ -84,6 +84,11 @@ class PenView: CanvasDrawable, DrawableView {
     }
   }
   
+  func bringToTop(canvas: CanvasView) {
+    canvas.setMaximumZPosition(to: layer)
+    state.model.zPosition = layer.zPosition
+  }
+  
   func render(state: PenViewState, oldState: PenViewState? = nil) {
     if state.model != oldState?.model {
       layer.shapePath = Self.createPath(model: state.model)

--- a/Annotations/Classes/Views/RectCanvas.swift
+++ b/Annotations/Classes/Views/RectCanvas.swift
@@ -2,7 +2,7 @@ import Foundation
 
 protocol RectCanvas: class, RectViewDelegate {
   var model: CanvasModel { get set }
-  func add(_ item: CanvasDrawable)
+  func add(_ item: CanvasDrawable, zPosition: CGFloat?)
 }
 
 extension RectCanvas {
@@ -14,7 +14,7 @@ extension RectCanvas {
                         globalIndex: model.index,
                         color: model.color)
     view.delegate = self
-    add(view)
+    add(view, zPosition: model.zPosition)
   }
   
   func createRectView(origin: PointModel, to: PointModel, color: ModelColor) -> (CanvasDrawable?, KnobView?) {

--- a/Annotations/Classes/Views/RectView.swift
+++ b/Annotations/Classes/Views/RectView.swift
@@ -10,7 +10,7 @@ struct RectViewState {
   var isSelected: Bool
 }
 
-class RectView: CanvasDrawable {
+class RectView: CanvasDrawable, DrawableView {
   var state: RectViewState {
     didSet {
       self.render(state: self.state, oldState: oldValue)
@@ -101,20 +101,7 @@ class RectView: CanvasDrawable {
   func knobAt(rectPoint: RectPoint) -> KnobView {
     return knobDict[rectPoint]!
   }
-  
-  func contains(point: PointModel) -> Bool {
-    return layer.path!.contains(point.cgPoint)
-  }
-  
-  func addTo(canvas: CanvasView) {
-    canvas.canvasLayer.addSublayer(layer)
-  }
-  
-  func removeFrom(canvas: CanvasView) {
-    layer.removeFromSuperlayer()
-    knobs.forEach { $0.removeFrom(canvas: canvas) }
-  }
-  
+
   func dragged(from: PointModel, to: PointModel) {
     let delta = from.deltaTo(to)
     state.model = model.copyMoving(delta: delta)

--- a/Annotations/Classes/Views/TextCanvas.swift
+++ b/Annotations/Classes/Views/TextCanvas.swift
@@ -8,7 +8,8 @@ protocol TextCanvas: TextAnnotationCanvas, TextViewDelegate where Self: CanvasVi
 extension TextCanvas {
   public func createTextView(text: String = "",
                              origin: PointModel,
-                             params: TextParams) -> TextViewAnnotation {
+                             params: TextParams,
+                             zPosition: CGFloat) -> TextViewAnnotation {
     let newTextView = createTextAnnotation(text: text,
                                            location: origin.cgPoint,
                                            textParams: params)
@@ -26,10 +27,10 @@ extension TextCanvas {
     let nsColor = params.foregroundColor ?? ModelColor.orange
     
     let newView = TextViewAnnotation(state: state,
-                                modelIndex: modelIndex,
-                                globalIndex: textModel.index,
-                                view: newTextView,
-                                color: nsColor)
+                                     modelIndex: modelIndex,
+                                     globalIndex: textModel.index,
+                                     view: newTextView,
+                                     color: nsColor)
     newView.delegate = self
 
     return newView
@@ -46,10 +47,10 @@ extension TextCanvas {
     let nsColor = textModel.style.foregroundColor ?? .orange
     
     let newView = TextViewAnnotation(state: state,
-                                modelIndex: index,
-                                globalIndex: textModel.index,
-                                view: newTextView,
-                                color: nsColor)
+                                     modelIndex: index,
+                                     globalIndex: textModel.index,
+                                     view: newTextView,
+                                     color: nsColor)
     newView.delegate = self
   
     

--- a/Annotations/Classes/Views/TextCanvas.swift
+++ b/Annotations/Classes/Views/TextCanvas.swift
@@ -62,7 +62,7 @@ extension TextCanvas {
     
     let view = createTextView(textModel: model, index: index)
     view.delegate = self
-    add(view)
+    add(view, zPosition: model.zPosition)
     view.updateFrame(with: model)
     view.deselect()
     view.isSelected = false
@@ -84,6 +84,8 @@ extension TextCanvas {
 extension TextCanvas {
   public func textAnnotationDidSelect(textAnnotation: TextAnnotation) {
     selectedItem = nil
+    // update zPosition of textAnnotation to the highest one if selected
+    textAnnotation.layer?.zPosition = generateZPosition()
   }
   
   public func textAnnotationDidDeselect(textAnnotation: TextAnnotation) {

--- a/Annotations/Classes/Views/TextViewAnnotation.swift
+++ b/Annotations/Classes/Views/TextViewAnnotation.swift
@@ -48,15 +48,15 @@ class TextViewAnnotation: CanvasDrawable {
     return false
   }
   
-  func addTo(canvas: CanvasView) {
-    view.addTo(canvas: canvas)
+  func addTo(canvas: CanvasView, zPosition: CGFloat?) {
+    view.addTo(canvas: canvas, zPosition: zPosition)
   }
   
   func removeFrom(canvas: CanvasView) {
     view.delete()
   }
   
-  // this method is never called here so should be just empty
+  
   func bringToTop(canvas: CanvasView) {
    
   }

--- a/Annotations/Classes/Views/TextViewAnnotation.swift
+++ b/Annotations/Classes/Views/TextViewAnnotation.swift
@@ -56,6 +56,11 @@ class TextViewAnnotation: CanvasDrawable {
     view.delete()
   }
   
+  // this method is never called here so should be just empty
+  func bringToTop(canvas: CanvasView) {
+   
+  }
+  
   func dragged(from: PointModel, to: PointModel) {
     
   }

--- a/Example/Annotations/test_drawing.json
+++ b/Example/Annotations/test_drawing.json
@@ -9,6 +9,7 @@
   },
   "texts": [
     {
+      "zPosition": 0,
       "index": 0,
       "origin": { "index": 0, "x": 50, "y": 50 },
       "text": "Blackbelt Labs",
@@ -19,6 +20,7 @@
       "legibilityEffectEnabled": true
     },
     {
+      "zPosition": 0,
       "index": 1,
       "origin": { "index": 1, "x": 150, "y": 150 },
       "text": "Some text",
@@ -29,6 +31,7 @@
       "legibilityEffectEnabled": false
     },
     {
+      "zPosition": 0,
       "index": 2,
       "origin": { "index": 2, "x": 200, "y": 250 },
       "text": "Julian Drapaylo",
@@ -41,6 +44,7 @@
   ],
   "arrows": [
     {
+      "zPosition": 0,
       "index": 3,
       "origin": { "index": 3, "x": 10, "y": 10 },
       "to": { "index": 3, "x": 80, "y": 80 },
@@ -49,6 +53,7 @@
   ],
   "pens": [
     {
+      "zPosition": 0,
       "index": 4,
       "points": [
         { "index": 4, "x": 350, "y": 150},
@@ -60,6 +65,7 @@
   ],
   "rects": [
     {
+      "zPosition": 0,
       "index": 5,
       "origin": { "index": 5, "x": 80, "y": 120 },
       "to": { "index": 5, "x": 100, "y": 100 },
@@ -69,6 +75,7 @@
   ],
   "obfuscates": [
     {
+      "zPosition": 0,
       "index": 6,
       "origin": { "index": 6, "x": 180, "y": 80 },
       "to": { "index": 6, "x": 100, "y": 100 },


### PR DESCRIPTION
@memstel we had a related BaseCamp task for it -> https://public.3.basecamp.com/p/1wLJvwKJLmvvZuKNC6zTQ5ZW

@memstel this PR adds `zPosition` `CALayer` support for Pens, Rects, Arrows, Numbers, and Texts.

Before these changes, if a user selected a shape its zPosition wasn't changed and it was odd to see that the selected shape is under another shapes. 

This change doesn't affect History (Undo / Redo). If a user presses Undo / Redo all zPositions will be reverted as they were in History. Currently, the History isn't realized efficiently and every undo / redraws all items from the snapshot in the stack. Therefore, if zPosition of some shape is changed we have to check all history stack snapshots and update its zPosition in all snapshots. 

Please look at the video:

https://user-images.githubusercontent.com/15073398/111075257-c6a9d080-84ef-11eb-8c61-a71336c8cfba.mov

