### PR TITLE
Fix issue of HighlightView on external displays

### DIFF
--- a/Annotations/Classes/Views/HighlightCanvas.swift
+++ b/Annotations/Classes/Views/HighlightCanvas.swift
@@ -3,6 +3,7 @@ import Foundation
 protocol HighlightCanvas: class, HighlightViewDelegate {
   var model: CanvasModel { get set }
   func add(_ item: CanvasDrawable)
+  var frame: CGRect { get set }
 }
 
 extension HighlightCanvas {
@@ -14,7 +15,8 @@ extension HighlightCanvas {
                              modelIndex: modelIndex,
                              globalIndex: model.index,
                              maskRects: rects,
-                             color: model.color)
+                             color: model.color,
+                             superviewFrame: frame)
     view.delegate = self
     add(view)
   }
@@ -34,7 +36,8 @@ extension HighlightCanvas {
                                 modelIndex: model.highlights.count - 1,
                                 globalIndex: newRect.index,
                                 maskRects: rects,
-                                color: color)
+                                color: color,
+                                superviewFrame: frame)
     newView.delegate = self
     
     let selectedKnob = newView.knobAt(rectPoint: .to)

--- a/Annotations/Classes/Views/HiglightView.swift
+++ b/Annotations/Classes/Views/HiglightView.swift
@@ -29,6 +29,8 @@ class HighlightView: CanvasDrawable {
   var globalIndex: Int
   var modelIndex: Int
   
+  var superviewFrame: CGRect
+  
   var color: NSColor? {
     guard let color = layer.strokeColor else { return nil }
     return NSColor(cgColor: color)
@@ -45,20 +47,22 @@ class HighlightView: CanvasDrawable {
                    modelIndex: Int,
                    globalIndex: Int,
                    maskRects: [CGRect],
-                   color: ModelColor) {
+                   color: ModelColor,
+                   superviewFrame: CGRect) {
     
     let layerColor = NSColor.color(from: color).cgColor
     let layer = type(of: self).createLayer(color: layerColor, state: state)
     
-    self.init(state: state, modelIndex: modelIndex, globalIndex: globalIndex, layer: layer, maskRects: maskRects)
+    self.init(state: state, modelIndex: modelIndex, globalIndex: globalIndex, layer: layer, maskRects: maskRects, superviewFrame: superviewFrame)
   }
   
-  init(state: HighlightViewState, modelIndex: Int, globalIndex: Int, layer: HighlightLayer, maskRects: [CGRect]) {
+  init(state: HighlightViewState, modelIndex: Int, globalIndex: Int, layer: HighlightLayer, maskRects: [CGRect], superviewFrame: CGRect) {
     self.state = state
     self.modelIndex = modelIndex
     self.globalIndex = globalIndex
     self.layer = layer
     self.maskRects = maskRects
+    self.superviewFrame = superviewFrame
     self.render(state: state)
   }
   
@@ -75,7 +79,7 @@ class HighlightView: CanvasDrawable {
       return layer.path!
     }
     set {
-      let frame = NSScreen.main?.frame ?? .zero
+      let frame = superviewFrame
       let path = CGPath(rect: frame, transform: nil)
       layer.path = path
       layer.bounds = path.boundingBox
@@ -166,7 +170,7 @@ class HighlightView: CanvasDrawable {
     }
     
     let maskPath = CGMutablePath()
-    let frame = NSScreen.main?.frame ?? .zero
+    let frame = canvas.frame
     maskRects.forEach {
       maskPath.addPath(NSBezierPath.concaveRectPath(rect: $0, radius: 4))
     }


### PR DESCRIPTION
@memstel 

The users complained about this issue here -> https://blackbeltlabs.slack.com/archives/C9E5M03CL/p1618434490016800
![gif_example](https://user-images.githubusercontent.com/15073398/123101262-876b1400-d43c-11eb-9944-9513bd11c21b.gif)

The areas were inversed incorrectly for some reason.

I found the reason. `NSScreen.main.frame` was used for the layer to that mask was applied. But if an external screen was used it worked incorrectly.

I used the superview's frame instead and it seems to work well now.

![image](https://user-images.githubusercontent.com/15073398/123101713-006a6b80-d43d-11eb-8a82-132d685395e8.png)

