### PR TITLE
Fix issues to ensure correct text rendering on macOS Ventura

### DIFF
--- a/Sources/Annotations/Classes/Model/Annotations/Text/Text.swift
+++ b/Sources/Annotations/Classes/Model/Annotations/Text/Text.swift
@@ -56,7 +56,13 @@ extension Text {
     var frame = self.frame
     let height = LegibilityTextHeightCalculator.lineWidth(for: style.fontSize ?? 0)
     frame.size.height += height
-    return frame
+    
+    // need integral here to ensure integer values for text view rendered frame
+    // without this statement the layout() method of canvasView is called every time
+    // textView frame is updated that lead to redundant calls and unpredicated behaviour
+    let integralFrame = frame.integral
+    
+    return integralFrame
   }
   
   mutating func updateFrameSize(_ size: CGSize) {

--- a/Sources/Annotations/Classes/View/Drawables/TextAnnotation/TextAnnotationView.swift
+++ b/Sources/Annotations/Classes/View/Drawables/TextAnnotation/TextAnnotationView.swift
@@ -10,8 +10,12 @@ class TextAnnotationView: NSView, DrawableElement {
   
   override var frame: NSRect {
     didSet {
-      textView.frame = bounds
-      legibilityTextView.frame = bounds
+      guard #available(macOS 13.0, *) else {
+        // update subframes in frames works well for macOS prior to 13.0 (Ventura)
+        textView.frame = bounds
+        legibilityTextView.frame = bounds
+        return
+      }
     }
   }
   
@@ -59,6 +63,16 @@ class TextAnnotationView: NSView, DrawableElement {
   private func setupUI() {
     wantsLayer = true
     addSubviews()
+  }
+  
+  override func layout() {
+    super.layout()
+    
+    // starting from macOS Ventura it is mandatory to update subviews here for correct work
+    if #available(macOS 13.0, *) {
+      textView.frame = bounds
+      legibilityTextView.frame = bounds
+    }
   }
   
   func addSubviews() {


### PR DESCRIPTION
This PR contains the next changes:
1) Add CGRect's `integral` to `renderFrame` property of Text annotation.
Without this statement, the `layout()` method of canvasView is called every time when `TextView` frame is updated and that case leads to redundant calls and unpredicted behaviour.
2) Fixed an issue when the text wasn't visible on macOS Ventura (it was already fixed before but this logic was lost after refactoring).
