### PR TITLE
Fix "import AppKit" warnings

### DIFF
--- a/Sources/Annotations/Classes/Extensions/NSColor+Extension.swift
+++ b/Sources/Annotations/Classes/Extensions/NSColor+Extension.swift
@@ -1,4 +1,4 @@
-import Cocoa
+import AppKit
 
 extension NSColor {
   public static func color(from modelColor: ModelColor) -> NSColor {

--- a/Sources/Annotations/Classes/Managers/Settings.swift
+++ b/Sources/Annotations/Classes/Managers/Settings.swift
@@ -1,4 +1,4 @@
-import Cocoa
+import AppKit
 import Combine
 
 public enum ObfuscateType: Equatable {

--- a/Sources/Annotations/Classes/Model/Selections/SelectionPath/Certain/RectSelectionPathCreator.swift
+++ b/Sources/Annotations/Classes/Model/Selections/SelectionPath/Certain/RectSelectionPathCreator.swift
@@ -3,6 +3,16 @@ import CoreGraphics
 
 final class RectSelectionPathCreator: SelectionPathCreator {
   func createSelectionPath(for annotation: Rect) -> CGPath {
-    RectPathCreator().createPath(for: annotation)
+    let path = RectPathCreator().createPath(for: annotation)
+      
+    if annotation.rectType == .regular {
+      // lineWidth + 15 points around for the rectangle selection path
+      return path.copy(strokingWithWidth: annotation.lineWidth + 15.0,
+                       lineCap: .butt,
+                       lineJoin: .miter,
+                       miterLimit: 1)
+    } else {
+      return path
+    }
   }
 }

--- a/Sources/Annotations/Classes/View/Canvas/DrawableCanvasView.swift
+++ b/Sources/Annotations/Classes/View/Canvas/DrawableCanvasView.swift
@@ -1,4 +1,4 @@
-import Cocoa
+import AppKit
 import Combine
 
 private enum MouseEventType {

--- a/Sources/Annotations/Classes/View/Helpers/ImageColorsCalculator.swift
+++ b/Sources/Annotations/Classes/View/Helpers/ImageColorsCalculator.swift
@@ -1,4 +1,4 @@
-import Cocoa
+import AppKit
 
 struct Pixel: Hashable, Equatable {
   let r: Float


### PR DESCRIPTION
Fix some warnings from Xcode where it complained that AppKit system frameworks wasn't imported in some places